### PR TITLE
Impl Issue #4: Refactor initialize() to suspend function

### DIFF
--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -33,12 +33,18 @@ interface InitSpark : SparkState {
     val timing: SparkTimingInfo
 
     /**
-     * Starts the initialization process of all defined sparks.
+     * Starts the initialization process of all defined sparks suspending during execution.
      *
      * It ensures no duplicate keys exist, all dependencies are satisfied,
      * and then launches appropriate runners for each type of spark.
      */
-    fun initialize()
+    suspend fun initialize()
+
+    /**
+     * Starts the initialization process in a blocking manner using runBlocking.
+     * Provided for backward compatibility and pure Java usage.
+     */
+    fun initializeBlocking()
 }
 
 internal class InitSparkImpl(
@@ -63,8 +69,8 @@ internal class InitSparkImpl(
 
     override val isInitialized: StateFlow<Boolean> = _isInitialized.asStateFlow()
 
-    override fun initialize() {
-        runBlocking {
+    override suspend fun initialize() {
+        coroutineScope {
             startAwaitable()
             with(createAndRunSparksJobs()) {
                 scope.launch {
@@ -76,6 +82,10 @@ internal class InitSparkImpl(
                 }
             }
         }
+    }
+
+    override fun initializeBlocking() {
+        runBlocking { initialize() }
     }
 
     private fun createAndRunSparksJobs(): Map<Key, Deferred<Unit>> =

--- a/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkKtKtTest.kt
+++ b/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkKtKtTest.kt
@@ -19,7 +19,8 @@ class InitSparkKtKtTest {
             override val isTrackableInitialized: StateFlow<Boolean> = MutableStateFlow(false)
             override val isInitialized = MutableStateFlow(false)
             override val timing = mockk<SparkTimingInfo>(relaxed = true)
-            override fun initialize() = Unit
+            override suspend fun initialize() = Unit
+            override fun initializeBlocking() = Unit
         }
 
         val job = launch { initSpark.waitUntilInitialized() }


### PR DESCRIPTION
Resolves #4

This PR updates `initialize()` in `InitSpark.kt` to be a `suspend` function instead of using native `runBlocking`. This ensures that any `AWAITABLE` sparks initialized on Android's Main Thread yield their execution appropriately to prevent freezing the UI or triggering ANRs.

For backwards compatibility and Java consumers, `initializeBlocking()` has been added.

All tests ran and pass.