### PR TITLE
Impl Issue #8: Ensure initialize() is idempotent

### DIFF
--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Initializes and manages the lifecycle of a set of SparkDeclarations.
@@ -60,6 +61,7 @@ internal class InitSparkImpl(
      */
     override val timing: SparkTimingInfo = SparkTimer.getInstance()
     private val sparkTimer: SparkTimer = SparkTimer.getInstance()
+    private val isStarted = AtomicBoolean(false)
 
     private val _isTrackAbleInitialized = MutableStateFlow(false)
 
@@ -70,6 +72,7 @@ internal class InitSparkImpl(
     override val isInitialized: StateFlow<Boolean> = _isInitialized.asStateFlow()
 
     override suspend fun initialize() {
+        if (!isStarted.compareAndSet(false, true)) return
         coroutineScope {
             startAwaitable()
             with(createAndRunSparksJobs()) {

--- a/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
+++ b/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -292,5 +293,37 @@ class InitSparkTest {
             b.invoke()
             c.invoke()
         }
+    }
+
+    @Test
+    fun `GIVEN initialized InitSpark WHEN initialize called again THEN sparks run only once`() = runTest {
+        val spark = mockk<Spark>(relaxed = true)
+        val config = buildSparks(emptySet()) {
+            await("s".asKey(), EmptyCoroutineContext, spark)
+        }
+        val initSpark = InitSpark(config, this)
+
+        initSpark.initialize()
+        initSpark.initialize()
+
+        coVerify(exactly = 1) { spark.invoke() }
+    }
+
+    @Test
+    fun `GIVEN in progress InitSpark WHEN initialize called again THEN second call ignored`() = runTest {
+        val spark = mockk<Spark> {
+            coEvery { this@mockk.invoke() } coAnswers { delay(1000) }
+        }
+        val config = buildSparks(emptySet()) {
+            await("s".asKey(), EmptyCoroutineContext, spark)
+        }
+        val initSpark = InitSpark(config, this)
+
+        launch { initSpark.initialize() }
+        delay(100)
+        initSpark.initialize()
+
+        advanceUntilIdle()
+        coVerify(exactly = 1) { spark.invoke() }
     }
 }


### PR DESCRIPTION
Resolves #8

This PR implements idempotency for `InitSpark.initialize()` to prevent multiple simultaneous or redundant initialization sequences.
- Added `AtomicBoolean` to `InitSparkImpl` to track if initialization has started.
- Subsequent calls to `initialize()` or `initializeBlocking()` while already started/completed will return immediately.
- Added unit tests to verify that double-calls or overlapping calls only execute sparks once.

The pre-commit workflow (build, test, detekt) was executed and passed before pushing.