### PR TITLE
Implement Spark Retry Policies and Backoff Strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/lib/bin/

--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -17,8 +17,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -124,34 +126,32 @@ internal class InitSparkImpl(
         }
 
     private suspend fun SparkDeclaration.runWithEvents() {
-        events.emit(SparkEvent.Started(key))
-
-        val error = flow<Throwable?> {
+        flow<Throwable?> {
             sparkTimer.measure(this@runWithEvents) { spark() }
             emit(null)
         }
             .retryWithPolicy(retryPolicy) { cause, attempt ->
-                sparkTimer
-                    .durationOf(this@runWithEvents)
+                sparkTimer.durationOf(this@runWithEvents)
                     .orDefault { ZERO }
                     .let { SparkEvent.Retry(key, attempt, it, cause) }
                     .letCo(events::emit)
             }
+            .onEach {
+                sparkTimer.durationOf(this@runWithEvents)
+                    .orDefault { ZERO }
+                    .let { SparkEvent.Completed(key, it) }
+                    .letCo(events::emit)
+            }
             .catch { e ->
                 if (e is CancellationException) throw e
-                emit(e)
+                sparkTimer.durationOf(this@runWithEvents)
+                    .orDefault { ZERO }
+                    .let { SparkEvent.Failed(key, it, e) }
+                    .letCo(events::emit)
+                if (importance == SparkImportance.CRITICAL) throw e
             }
-            .first()
-
-        val duration = sparkTimer.durationOf(this) ?: ZERO
-        if (error == null) {
-            events.emit(SparkEvent.Completed(key, duration))
-        } else {
-            events.emit(SparkEvent.Failed(key, duration, error))
-            if (importance == SparkImportance.CRITICAL) {
-                throw error
-            }
-        }
+            .onStart { events.emit(SparkEvent.Started(key)) }
+            .collect()
     }
 
     private suspend fun startAwaitable() = config

--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -1,5 +1,7 @@
 package com.github.ktomek.initspark
 
+import com.github.ktomek.funktional.letCo
+import com.github.ktomek.funktional.orDefault
 import com.github.ktomek.initspark.SparkType.AWAITABLE
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -8,13 +10,22 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
 
 /**
  * Initializes and manages the lifecycle of a set of SparkDeclarations.
@@ -117,15 +128,31 @@ internal class InitSparkImpl(
     @Suppress("TooGenericExceptionCaught")
     private suspend fun SparkDeclaration.runWithEvents() {
         events.emit(SparkEvent.Started(key))
-        try {
-            sparkTimer.measure(this) { spark() }
-            events.emit(SparkEvent.Completed(key, sparkTimer.durationOf(this)!!))
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            events.emit(SparkEvent.Failed(key, sparkTimer.durationOf(this)!!, e))
+
+        val error = flow<Throwable?> {
+            sparkTimer.measure(this@runWithEvents) { spark() }
+            emit(null)
+        }
+            .retryWithPolicy(retryPolicy) { cause, attempt ->
+                sparkTimer
+                    .durationOf(this@runWithEvents)
+                    .orDefault { ZERO }
+                    .let { SparkEvent.Retry(key, attempt, it, cause)}
+                    .letCo(events::emit)
+            }
+            .catch { e ->
+                if (e is CancellationException) throw e
+                emit(e)
+            }
+            .first()
+
+        val duration = sparkTimer.durationOf(this) ?: ZERO
+        if (error == null) {
+            events.emit(SparkEvent.Completed(key, duration))
+        } else {
+            events.emit(SparkEvent.Failed(key, duration, error))
             if (importance == SparkImportance.CRITICAL) {
-                throw e
+                throw error
             }
         }
     }
@@ -133,9 +160,7 @@ internal class InitSparkImpl(
     private suspend fun startAwaitable() = config
         .declarations
         .filter { it.type == AWAITABLE }
-        .forEach { sparkDeclaration ->
-            sparkDeclaration.runWithEvents()
-        }
+        .forEach { sparkDeclaration -> sparkDeclaration.runWithEvents() }
 
     private suspend fun startAsyncSparks(jobs: Map<Key, Deferred<Unit>>) {
         config
@@ -154,6 +179,25 @@ internal class InitSparkImpl(
             .map(SparkDeclaration::key)
             .mapNotNull(jobs::get)
             .awaitAll()
+    }
+}
+
+private fun <T> Flow<T>.retryWithPolicy(
+    policy: RetryPolicy?,
+    onRetry: suspend (cause: Throwable, attempt: Int) -> Unit
+): Flow<T> = retryWhen { cause, attempt ->
+    if (cause is CancellationException) throw cause
+    val maxRetries = policy?.retryCount?.toLong() ?: 0L
+    if (attempt < maxRetries) {
+        val nextAttempt = (attempt + 1).toInt()
+        onRetry(cause, nextAttempt)
+        policy
+            ?.calculateDelay(nextAttempt)
+            ?.takeIf { delayMillis -> delayMillis > 0 }
+            ?.let { delayMillis -> delay(delayMillis) }
+        true
+    } else {
+        false
     }
 }
 

--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -126,9 +126,9 @@ internal class InitSparkImpl(
         }
 
     private suspend fun SparkDeclaration.runWithEvents() {
-        flow<Throwable?> {
+        flow {
             sparkTimer.measure(this@runWithEvents) { spark() }
-            emit(null)
+            emit(Unit)
         }
             .retryWithPolicy(retryPolicy) { cause, attempt ->
                 sparkTimer.durationOf(this@runWithEvents)

--- a/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/InitSpark.kt
@@ -17,14 +17,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 
 /**
@@ -125,7 +123,6 @@ internal class InitSparkImpl(
             this@createJob.runWithEvents()
         }
 
-    @Suppress("TooGenericExceptionCaught")
     private suspend fun SparkDeclaration.runWithEvents() {
         events.emit(SparkEvent.Started(key))
 
@@ -137,7 +134,7 @@ internal class InitSparkImpl(
                 sparkTimer
                     .durationOf(this@runWithEvents)
                     .orDefault { ZERO }
-                    .let { SparkEvent.Retry(key, attempt, it, cause)}
+                    .let { SparkEvent.Retry(key, attempt, it, cause) }
                     .letCo(events::emit)
             }
             .catch { e ->

--- a/lib/src/main/java/com/github/ktomek/initspark/RetryPolicy.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/RetryPolicy.kt
@@ -1,0 +1,47 @@
+package com.github.ktomek.initspark
+
+import kotlin.math.pow
+
+/**
+ * Strategy for delay between retry attempts.
+ */
+sealed interface Backoff {
+    /** No delay between retries. */
+    data object None : Backoff
+
+    /** Fixed delay between retries. */
+    data class Fixed(val delayMillis: Long) : Backoff
+
+    /**
+     * Exponential delay between retries.
+     * Starts with [initialDelayMillis] and multiplies by [factor] each time.
+     */
+    data class Exponential(val initialDelayMillis: Long, val factor: Double = 2.0) : Backoff
+}
+
+/**
+ * Policy defining how a Spark should be retried upon failure.
+ *
+ * @property retryCount Number of times to retry before giving up.
+ * @property backoff Strategy to determine the delay between retries.
+ */
+data class RetryPolicy(
+    val retryCount: Int,
+    val backoff: Backoff = Backoff.None
+) {
+    /**
+     * Calculates the delay for a given retry [attempt].
+     * @param attempt The 1-based index of the retry attempt.
+     */
+    fun calculateDelay(attempt: Int): Long =
+        when (backoff) {
+            is Backoff.None -> 0L
+            is Backoff.Fixed -> backoff.delayMillis
+            is Backoff.Exponential -> calculateExponentialDelay(backoff, attempt)
+        }
+
+    private fun calculateExponentialDelay(
+        backoff: Backoff.Exponential,
+        attempt: Int
+    ): Long = (backoff.initialDelayMillis * backoff.factor.pow(attempt - 1)).toLong()
+}

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkBuilder.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkBuilder.kt
@@ -22,10 +22,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
     fun await(
         key: Key? = null,
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
-        spark: Spark
+        policy: SparkPolicy = SparkPolicy(),
+        spark: Spark,
     ) {
         declarations.add(
             spark.toDeclaration(
@@ -33,8 +31,7 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = AWAITABLE,
                 needs = emptySet(),
                 context = context,
-                importance = importance,
-                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
+                policy = policy
             )
         )
     }
@@ -51,16 +48,12 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
     inline fun <reified T : Spark> await(
         key: Key? = null,
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
+        policy: SparkPolicy = SparkPolicy(),
     ) {
         await(
             key = key,
             context = context,
-            importance = importance,
-            retryCount = retryCount,
-            backoff = backoff,
+            policy = policy,
             spark = sparks.requireSpark<T>()
         )
     }
@@ -77,9 +70,7 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
+        policy: SparkPolicy = SparkPolicy(),
         spark: Spark
     ) {
         declarations.add(
@@ -88,8 +79,7 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = TRACKABLE,
                 needs = needs,
                 context = context,
-                importance = importance,
-                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
+                policy = policy
             )
         )
     }
@@ -98,17 +88,13 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
+        policy: SparkPolicy = SparkPolicy(),
     ) {
         async(
             key = key,
             needs = needs,
             context = context,
-            importance = importance,
-            retryCount = retryCount,
-            backoff = backoff,
+            policy = policy,
             spark = sparks.requireSpark<T>()
         )
     }
@@ -125,9 +111,7 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
+        policy: SparkPolicy = SparkPolicy(),
         spark: Spark
     ) {
         declarations.add(
@@ -136,8 +120,7 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = FIRE_AND_FORGET,
                 needs = needs,
                 context = context,
-                importance = importance,
-                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
+                policy = policy
             )
         )
     }
@@ -153,17 +136,13 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
-        importance: SparkImportance = SparkImportance.CRITICAL,
-        retryCount: Int = 0,
-        backoff: Backoff = Backoff.None,
+        policy: SparkPolicy = SparkPolicy(),
     ) {
         spark(
             key = key,
             needs = needs,
             context = context,
-            importance = importance,
-            retryCount = retryCount,
-            backoff = backoff,
+            policy = policy,
             spark = sparks.requireSpark<T>()
         )
     }
@@ -173,15 +152,13 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         type: SparkType,
         needs: Set<Key>,
         context: CoroutineContext,
-        importance: SparkImportance,
-        retryPolicy: RetryPolicy? = null,
+        policy: SparkPolicy
     ): SparkDeclaration = SparkDeclaration(
         key = key ?: javaClass.simpleName.asKey(),
         needs = needs,
         type = type,
         coroutineContext = context,
-        importance = importance,
-        retryPolicy = retryPolicy,
+        policy = policy,
         spark = this
     )
 

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkBuilder.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkBuilder.kt
@@ -23,6 +23,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
         spark: Spark
     ) {
         declarations.add(
@@ -31,7 +33,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = AWAITABLE,
                 needs = emptySet(),
                 context = context,
-                importance = importance
+                importance = importance,
+                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
             )
         )
     }
@@ -49,8 +52,17 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         key: Key? = null,
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
     ) {
-        await(key = key, context = context, importance = importance, spark = sparks.requireSpark<T>())
+        await(
+            key = key,
+            context = context,
+            importance = importance,
+            retryCount = retryCount,
+            backoff = backoff,
+            spark = sparks.requireSpark<T>()
+        )
     }
 
     /**
@@ -66,6 +78,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
         spark: Spark
     ) {
         declarations.add(
@@ -74,7 +88,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = TRACKABLE,
                 needs = needs,
                 context = context,
-                importance = importance
+                importance = importance,
+                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
             )
         )
     }
@@ -84,8 +99,18 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
     ) {
-        async(key = key, needs = needs, context = context, importance = importance, spark = sparks.requireSpark<T>())
+        async(
+            key = key,
+            needs = needs,
+            context = context,
+            importance = importance,
+            retryCount = retryCount,
+            backoff = backoff,
+            spark = sparks.requireSpark<T>()
+        )
     }
 
     /**
@@ -101,6 +126,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
         spark: Spark
     ) {
         declarations.add(
@@ -109,7 +136,8 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
                 type = FIRE_AND_FORGET,
                 needs = needs,
                 context = context,
-                importance = importance
+                importance = importance,
+                retryPolicy = if (retryCount > 0) RetryPolicy(retryCount, backoff) else null
             )
         )
     }
@@ -126,8 +154,18 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         needs: Set<Key> = emptySet(),
         context: CoroutineContext = EmptyCoroutineContext,
         importance: SparkImportance = SparkImportance.CRITICAL,
+        retryCount: Int = 0,
+        backoff: Backoff = Backoff.None,
     ) {
-        spark(key = key, needs = needs, context = context, importance = importance, spark = sparks.requireSpark<T>())
+        spark(
+            key = key,
+            needs = needs,
+            context = context,
+            importance = importance,
+            retryCount = retryCount,
+            backoff = backoff,
+            spark = sparks.requireSpark<T>()
+        )
     }
 
     private fun Spark.toDeclaration(
@@ -136,12 +174,14 @@ class SparkBuilder internal constructor(val sparks: Set<Spark>) {
         needs: Set<Key>,
         context: CoroutineContext,
         importance: SparkImportance,
+        retryPolicy: RetryPolicy? = null,
     ): SparkDeclaration = SparkDeclaration(
         key = key ?: javaClass.simpleName.asKey(),
         needs = needs,
         type = type,
         coroutineContext = context,
         importance = importance,
+        retryPolicy = retryPolicy,
         spark = this
     )
 

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkDeclaration.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkDeclaration.kt
@@ -48,9 +48,22 @@ internal constructor(
     val needs: Set<Key> = emptySet(),
     val type: SparkType = FIRE_AND_FORGET,
     val coroutineContext: CoroutineContext = EmptyCoroutineContext,
-    val importance: SparkImportance = SparkImportance.CRITICAL,
-    val retryPolicy: RetryPolicy? = null,
+    val policy: SparkPolicy = SparkPolicy(),
     val spark: Spark
+) {
+    val importance: SparkImportance get() = policy.importance
+    val retryPolicy: RetryPolicy? get() = policy.retry
+}
+
+/**
+ * Policy defining execution behavior of a Spark.
+ *
+ * @property importance Importance level (CRITICAL or OPTIONAL).
+ * @property retry Optional retry strategy.
+ */
+data class SparkPolicy(
+    val importance: SparkImportance = SparkImportance.CRITICAL,
+    val retry: RetryPolicy? = null
 )
 
 /**

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkDeclaration.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkDeclaration.kt
@@ -49,6 +49,7 @@ internal constructor(
     val type: SparkType = FIRE_AND_FORGET,
     val coroutineContext: CoroutineContext = EmptyCoroutineContext,
     val importance: SparkImportance = SparkImportance.CRITICAL,
+    val retryPolicy: RetryPolicy? = null,
     val spark: Spark
 )
 

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkState.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkState.kt
@@ -26,12 +26,18 @@ interface SparkState {
 }
 
 /**
- * Sealed class representing atomic lifecycle events emitted by the InitSpark orchestrator.
+ * Sealed interface representing atomic lifecycle events emitted by the InitSpark orchestrator.
  */
-sealed class SparkEvent {
-    abstract val key: Key
+sealed interface SparkEvent {
+    val key: Key
 
-    data class Started(override val key: Key) : SparkEvent()
-    data class Completed(override val key: Key, val duration: Duration) : SparkEvent()
-    data class Failed(override val key: Key, val duration: Duration, val error: Throwable) : SparkEvent()
+    data class Started(override val key: Key) : SparkEvent
+    data class Completed(override val key: Key, val duration: Duration) : SparkEvent
+    data class Failed(override val key: Key, val duration: Duration, val error: Throwable) : SparkEvent
+    data class Retry(
+        override val key: Key,
+        val retryCount: Int,
+        val duration: Duration,
+        val error: Throwable
+    ) : SparkEvent
 }

--- a/lib/src/main/java/com/github/ktomek/initspark/SparkTimer.kt
+++ b/lib/src/main/java/com/github/ktomek/initspark/SparkTimer.kt
@@ -53,7 +53,7 @@ internal class SparkTimer(private val timeProvider: TimeProvider = DefaultTimePr
             totalExecutionDeltaDuration = firstStartTime.elapsedNow()
 
             val type = declaration.type
-            val (startMark, _) = typeExecutionDeltaMarks[type]!!
+            val (startMark, _) = typeExecutionDeltaMarks[type] ?: (mark to null)
             typeExecutionDeltaMarks[type] = startMark to startMark.elapsedNow()
         }
     }

--- a/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
+++ b/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
@@ -76,7 +76,7 @@ class InitSparkTest {
                         needs = emptySet(),
                         type = SparkType.AWAITABLE,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = awaitableSpark
                     ),
                     SparkDeclaration(
@@ -84,7 +84,7 @@ class InitSparkTest {
                         needs = emptySet(),
                         type = SparkType.TRACKABLE,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = trackableSpark
                     ),
                     SparkDeclaration(
@@ -92,7 +92,7 @@ class InitSparkTest {
                         needs = emptySet(),
                         type = SparkType.FIRE_AND_FORGET,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = spark
                     )
                 )
@@ -128,7 +128,7 @@ class InitSparkTest {
                     needs = emptySet(),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = spark1
                 ),
                 SparkDeclaration(
@@ -136,7 +136,7 @@ class InitSparkTest {
                     needs = emptySet(),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = spark2
                 )
             )
@@ -178,7 +178,7 @@ class InitSparkTest {
                         needs = emptySet(),
                         type = SparkType.FIRE_AND_FORGET,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = spark
                     )
                 )
@@ -203,7 +203,7 @@ class InitSparkTest {
                     needs = setOf("first".asKey()),
                     type = SparkType.TRACKABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = shared
                 ),
                 SparkDeclaration(
@@ -211,7 +211,7 @@ class InitSparkTest {
                     needs = emptySet(),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = first
                 )
             )
@@ -238,7 +238,7 @@ class InitSparkTest {
                         needs = emptySet(),
                         type = SparkType.AWAITABLE,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = dep
                     ),
                     SparkDeclaration(
@@ -246,7 +246,7 @@ class InitSparkTest {
                         needs = setOf("dep".asKey()),
                         type = SparkType.TRACKABLE,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = a
                     ),
                     SparkDeclaration(
@@ -254,7 +254,7 @@ class InitSparkTest {
                         needs = setOf("dep".asKey()),
                         type = SparkType.FIRE_AND_FORGET,
                         coroutineContext = EmptyCoroutineContext,
-                        importance = SparkImportance.CRITICAL,
+                        policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                         spark = b
                     )
                 )
@@ -279,7 +279,7 @@ class InitSparkTest {
                     needs = emptySet(),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = a
                 ),
                 SparkDeclaration(
@@ -287,7 +287,7 @@ class InitSparkTest {
                     needs = setOf("a".asKey()),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = b
                 ),
                 SparkDeclaration(
@@ -295,7 +295,7 @@ class InitSparkTest {
                     needs = setOf("b".asKey()),
                     type = SparkType.AWAITABLE,
                     coroutineContext = EmptyCoroutineContext,
-                    importance = SparkImportance.CRITICAL,
+                    policy = SparkPolicy(importance = SparkImportance.CRITICAL),
                     spark = c
                 )
             )
@@ -406,7 +406,7 @@ class InitSparkTest {
             coEvery { this@mockk.invoke() } throws error
         }
         val config = buildSparks(emptySet()) {
-            await(key = "s".asKey(), importance = SparkImportance.OPTIONAL, spark = spark)
+            await(key = "s".asKey(), policy = SparkPolicy(importance = SparkImportance.OPTIONAL), spark = spark)
         }
         val initSpark = InitSpark(config, this)
 
@@ -419,6 +419,7 @@ class InitSparkTest {
     }
 
     @Test
+    @Suppress("TooGenericExceptionThrown")
     fun `GIVEN spark with retryCount WHEN fails twice and succeeds on third THEN initialization completes`() =
         runTest {
             val spark = mockk<Spark>()
@@ -429,7 +430,7 @@ class InitSparkTest {
             }
 
             val config = buildSparks(emptySet()) {
-                await(key = "retry".asKey(), retryCount = 2, spark = spark)
+                await(key = "retry".asKey(), policy = SparkPolicy(retry = RetryPolicy(2)), spark = spark)
             }
             val initSpark = InitSpark(config, this)
 
@@ -455,7 +456,7 @@ class InitSparkTest {
         }
 
         val config = buildSparks(emptySet()) {
-            await(key = "fail".asKey(), retryCount = 2, spark = spark)
+            await(key = "fail".asKey(), policy = SparkPolicy(retry = RetryPolicy(2)), spark = spark)
         }
         val initSpark = InitSpark(config, this)
 
@@ -482,8 +483,7 @@ class InitSparkTest {
         val config = buildSparks(emptySet()) {
             await(
                 key = "delay".asKey(),
-                retryCount = 1,
-                backoff = Backoff.Fixed(1000),
+                policy = SparkPolicy(retry = RetryPolicy(1, Backoff.Fixed(1000))),
                 spark = spark
             )
         }
@@ -511,8 +511,7 @@ class InitSparkTest {
         val config = buildSparks(emptySet()) {
             await(
                 key = "expo".asKey(),
-                retryCount = 2,
-                backoff = Backoff.Exponential(1000, 2.0),
+                policy = SparkPolicy(retry = RetryPolicy(2, Backoff.Exponential(1000, 2.0))),
                 spark = spark
             )
         }

--- a/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
+++ b/lib/src/test/kotlin/com/github/ktomek/initspark/InitSparkTest.kt
@@ -72,28 +72,28 @@ class InitSparkTest {
             val config = SparkConfiguration(
                 listOf(
                     SparkDeclaration(
-                        "await".asKey(),
-                        emptySet(),
-                        SparkType.AWAITABLE,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        awaitableSpark
+                        key = "await".asKey(),
+                        needs = emptySet(),
+                        type = SparkType.AWAITABLE,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = awaitableSpark
                     ),
                     SparkDeclaration(
-                        "track".asKey(),
-                        emptySet(),
-                        SparkType.TRACKABLE,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        trackableSpark
+                        key = "track".asKey(),
+                        needs = emptySet(),
+                        type = SparkType.TRACKABLE,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = trackableSpark
                     ),
                     SparkDeclaration(
-                        "default".asKey(),
-                        emptySet(),
-                        SparkType.FIRE_AND_FORGET,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        spark
+                        key = "default".asKey(),
+                        needs = emptySet(),
+                        type = SparkType.FIRE_AND_FORGET,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = spark
                     )
                 )
             )
@@ -124,20 +124,20 @@ class InitSparkTest {
         val config = SparkConfiguration(
             listOf(
                 SparkDeclaration(
-                    "s1".asKey(),
-                    emptySet(),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    spark1
+                    key = "s1".asKey(),
+                    needs = emptySet(),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = spark1
                 ),
                 SparkDeclaration(
-                    "s2".asKey(),
-                    emptySet(),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    spark2
+                    key = "s2".asKey(),
+                    needs = emptySet(),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = spark2
                 )
             )
         )
@@ -174,12 +174,12 @@ class InitSparkTest {
             val config = SparkConfiguration(
                 listOf(
                     SparkDeclaration(
-                        "d".asKey(),
-                        emptySet(),
-                        SparkType.FIRE_AND_FORGET,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        spark
+                        key = "d".asKey(),
+                        needs = emptySet(),
+                        type = SparkType.FIRE_AND_FORGET,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = spark
                     )
                 )
             )
@@ -199,20 +199,20 @@ class InitSparkTest {
         val config = SparkConfiguration(
             listOf(
                 SparkDeclaration(
-                    "shared".asKey(),
-                    setOf("first".asKey()),
-                    SparkType.TRACKABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    shared
+                    key = "shared".asKey(),
+                    needs = setOf("first".asKey()),
+                    type = SparkType.TRACKABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = shared
                 ),
                 SparkDeclaration(
-                    "first".asKey(),
-                    emptySet(),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    first
+                    key = "first".asKey(),
+                    needs = emptySet(),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = first
                 )
             )
         )
@@ -234,28 +234,28 @@ class InitSparkTest {
             val config = SparkConfiguration(
                 listOf(
                     SparkDeclaration(
-                        "dep".asKey(),
-                        emptySet(),
-                        SparkType.AWAITABLE,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        dep
+                        key = "dep".asKey(),
+                        needs = emptySet(),
+                        type = SparkType.AWAITABLE,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = dep
                     ),
                     SparkDeclaration(
-                        "a".asKey(),
-                        setOf("dep".asKey()),
-                        SparkType.TRACKABLE,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        a
+                        key = "a".asKey(),
+                        needs = setOf("dep".asKey()),
+                        type = SparkType.TRACKABLE,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = a
                     ),
                     SparkDeclaration(
-                        "b".asKey(),
-                        setOf("dep".asKey()),
-                        SparkType.FIRE_AND_FORGET,
-                        EmptyCoroutineContext,
-                        SparkImportance.CRITICAL,
-                        b
+                        key = "b".asKey(),
+                        needs = setOf("dep".asKey()),
+                        type = SparkType.FIRE_AND_FORGET,
+                        coroutineContext = EmptyCoroutineContext,
+                        importance = SparkImportance.CRITICAL,
+                        spark = b
                     )
                 )
             )
@@ -275,28 +275,28 @@ class InitSparkTest {
         val config = SparkConfiguration(
             listOf(
                 SparkDeclaration(
-                    "a".asKey(),
-                    emptySet(),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    a
+                    key = "a".asKey(),
+                    needs = emptySet(),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = a
                 ),
                 SparkDeclaration(
-                    "b".asKey(),
-                    setOf("a".asKey()),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    b
+                    key = "b".asKey(),
+                    needs = setOf("a".asKey()),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = b
                 ),
                 SparkDeclaration(
-                    "c".asKey(),
-                    setOf("b".asKey()),
-                    SparkType.AWAITABLE,
-                    EmptyCoroutineContext,
-                    SparkImportance.CRITICAL,
-                    c
+                    key = "c".asKey(),
+                    needs = setOf("b".asKey()),
+                    type = SparkType.AWAITABLE,
+                    coroutineContext = EmptyCoroutineContext,
+                    importance = SparkImportance.CRITICAL,
+                    spark = c
                 )
             )
         )
@@ -406,7 +406,7 @@ class InitSparkTest {
             coEvery { this@mockk.invoke() } throws error
         }
         val config = buildSparks(emptySet()) {
-            await("s".asKey(), importance = SparkImportance.OPTIONAL, spark = spark)
+            await(key = "s".asKey(), importance = SparkImportance.OPTIONAL, spark = spark)
         }
         val initSpark = InitSpark(config, this)
 
@@ -416,5 +416,124 @@ class InitSparkTest {
             val failed = awaitItem() as SparkEvent.Failed
             assertEquals(error, failed.error)
         }
+    }
+
+    @Test
+    fun `GIVEN spark with retryCount WHEN fails twice and succeeds on third THEN initialization completes`() =
+        runTest {
+            val spark = mockk<Spark>()
+            var attempts = 0
+            coEvery { spark.invoke() } coAnswers {
+                attempts++
+                if (attempts < 3) throw RuntimeException("Fail $attempts")
+            }
+
+            val config = buildSparks(emptySet()) {
+                await(key = "retry".asKey(), retryCount = 2, spark = spark)
+            }
+            val initSpark = InitSpark(config, this)
+
+            initSpark.events.test {
+                initSpark.initialize()
+                assertTrue(awaitItem() is SparkEvent.Started)
+                val retry1 = awaitItem() as SparkEvent.Retry
+                assertEquals(1, retry1.retryCount)
+                val retry2 = awaitItem() as SparkEvent.Retry
+                assertEquals(2, retry2.retryCount)
+                assertTrue(awaitItem() is SparkEvent.Completed)
+                expectNoEvents()
+            }
+
+            coVerify(exactly = 3) { spark.invoke() }
+        }
+
+    @Test
+    fun `GIVEN spark with retryCount WHEN all attempts fail THEN initialization fails`() = runTest {
+        val error = RuntimeException("Total failure")
+        val spark = mockk<Spark> {
+            coEvery { this@mockk.invoke() } throws error
+        }
+
+        val config = buildSparks(emptySet()) {
+            await(key = "fail".asKey(), retryCount = 2, spark = spark)
+        }
+        val initSpark = InitSpark(config, this)
+
+        initSpark.events.test {
+            assertFailsWith<RuntimeException> {
+                initSpark.initialize()
+            }
+            assertTrue(awaitItem() is SparkEvent.Started)
+            assertTrue(awaitItem() is SparkEvent.Retry)
+            assertTrue(awaitItem() is SparkEvent.Retry)
+            val failed = awaitItem() as SparkEvent.Failed
+            assertEquals(error, failed.error)
+        }
+
+        coVerify(exactly = 3) { spark.invoke() }
+    }
+
+    @Test
+    fun `GIVEN spark with Fixed backoff WHEN retrying THEN delay is respected`() = runTest {
+        val spark = mockk<Spark> {
+            coEvery { this@mockk.invoke() } throws RuntimeException("Fail")
+        }
+
+        val config = buildSparks(emptySet()) {
+            await(
+                key = "delay".asKey(),
+                retryCount = 1,
+                backoff = Backoff.Fixed(1000),
+                spark = spark
+            )
+        }
+        val initSpark = InitSpark(config, this)
+
+        launch {
+            assertFailsWith<RuntimeException> {
+                initSpark.initialize()
+            }
+        }
+
+        advanceTimeBy(500)
+        coVerify(exactly = 1) { spark.invoke() } // Initial attempt
+
+        advanceTimeBy(600)
+        coVerify(exactly = 2) { spark.invoke() } // Retry after 1000ms
+    }
+
+    @Test
+    fun `GIVEN spark with Exponential backoff WHEN retrying THEN delay increases`() = runTest {
+        val spark = mockk<Spark> {
+            coEvery { this@mockk.invoke() } throws RuntimeException("Fail")
+        }
+
+        val config = buildSparks(emptySet()) {
+            await(
+                key = "expo".asKey(),
+                retryCount = 2,
+                backoff = Backoff.Exponential(1000, 2.0),
+                spark = spark
+            )
+        }
+        val initSpark = InitSpark(config, this)
+
+        launch {
+            assertFailsWith<RuntimeException> {
+                initSpark.initialize()
+            }
+        }
+
+        advanceTimeBy(500)
+        coVerify(exactly = 1) { spark.invoke() } // Initial attempt
+
+        advanceTimeBy(600)
+        coVerify(exactly = 2) { spark.invoke() } // First retry after 1000ms
+
+        advanceTimeBy(1500)
+        coVerify(exactly = 2) { spark.invoke() } // Still waiting for second retry (need 2000ms more)
+
+        advanceTimeBy(600)
+        coVerify(exactly = 3) { spark.invoke() } // Second retry after 2000ms more
     }
 }

--- a/lib/src/test/kotlin/com/github/ktomek/initspark/RetryPolicyTest.kt
+++ b/lib/src/test/kotlin/com/github/ktomek/initspark/RetryPolicyTest.kt
@@ -1,0 +1,43 @@
+package com.github.ktomek.initspark
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class RetryPolicyTest {
+
+    @Test
+    fun `GIVEN Backoff None WHEN calculateDelay THEN returns 0`() {
+        val policy = RetryPolicy(3, Backoff.None)
+        assertEquals(0L, policy.calculateDelay(1))
+        assertEquals(0L, policy.calculateDelay(2))
+        assertEquals(0L, policy.calculateDelay(3))
+    }
+
+    @Test
+    fun `GIVEN Backoff Fixed WHEN calculateDelay THEN returns fixed value`() {
+        val policy = RetryPolicy(3, Backoff.Fixed(1000))
+        assertEquals(1000L, policy.calculateDelay(1))
+        assertEquals(1000L, policy.calculateDelay(2))
+        assertEquals(1000L, policy.calculateDelay(3))
+    }
+
+    @Test
+    fun `GIVEN Backoff Exponential WHEN calculateDelay THEN returns increasing values`() {
+        val policy = RetryPolicy(3, Backoff.Exponential(1000, 2.0))
+        // attempt is 1-based index (1st retry attempt)
+        // 1st retry: 1000 * 2^0 = 1000
+        assertEquals(1000L, policy.calculateDelay(1))
+        // 2nd retry: 1000 * 2^1 = 2000
+        assertEquals(2000L, policy.calculateDelay(2))
+        // 3rd retry: 1000 * 2^2 = 4000
+        assertEquals(4000L, policy.calculateDelay(3))
+    }
+
+    @Test
+    fun `GIVEN Backoff Exponential with factor 1_5 WHEN calculateDelay THEN returns correct values`() {
+        val policy = RetryPolicy(3, Backoff.Exponential(1000, 1.5))
+        assertEquals(1000L, policy.calculateDelay(1))
+        assertEquals(1500L, policy.calculateDelay(2))
+        assertEquals(2250L, policy.calculateDelay(3))
+    }
+}


### PR DESCRIPTION
This PR implements a robust, reactive Spark Retry Policy mechanism.

Key features:
- **Flow-based Orchestration**: Uses a custom `retryWithPolicy` operator for clean, single-responsibility retry logic.
- **Configurable Backoff**: Supports `None`, `Fixed`, and `Exponential` backoff strategies.
- **Enhanced Visibility**: Converted `SparkEvent` to a sealed interface and added a `Retry` event.
- **Robust Timing**: Eliminated unsafe `!!` assertions in timing lookups for improved stability.
- **Comprehensive Testing**: Added unit tests, including dedicated tests for `RetryPolicy`.